### PR TITLE
fix: revert springdoc-openapi to 2.8.6 for Spring Boot 3.5 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<lombok.version>1.18.42</lombok.version>
 		<snmp4j-version>3.9.6</snmp4j-version>
 		<spring-cloud.version>2025.1.0</spring-cloud.version>
-		<spring-doc.version>3.0.1</spring-doc.version>
+		<spring-doc.version>2.8.6</spring-doc.version>
 		<spring-shell.version>3.4.0</spring-shell.version>
 	</properties>
 	<build>


### PR DESCRIPTION
## Summary
- Revert springdoc-openapi from 3.0.1 to 2.8.6

## Problem
springdoc-openapi 3.0.1 is incompatible with Spring Boot 3.5.0, causing:
- `ClassNotFoundException: org.springframework.boot.web.error.ErrorPageRegistrar`
- Bean definition conflicts for `conventionErrorViewResolver`

## Test plan
- [x] Build passes locally
- [x] Application starts successfully
- [x] Swagger UI accessible at `/swagger-ui/index.html`
- [x] Health endpoint returns UP