### PR TITLE
ci: use GITHUB_TOKEN for GHCR auth and dynamic repo owner

### DIFF
--- a/.github/workflows/promsnmp-build.yaml
+++ b/.github/workflows/promsnmp-build.yaml
@@ -22,6 +22,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -57,7 +60,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build container image
         uses: docker/build-push-action@v6
         with:
@@ -68,4 +71,4 @@ jobs:
             DATE=${{ env.BUILD_DATE }}
             GIT_SHORT_HASH=${{ env.SHORT_GIT_SHA }}
             VERSION=${{ env.VERSION }}
-          tags: ghcr.io/pbrane/promsnmp-metrics:${{ env.SHORT_GIT_SHA }},ghcr.io/pbrane/promsnmp-metrics:${{ env.VERSION }},ghcr.io/pbrane/promsnmp-metrics:${{ env.OCI_FLOATING_TAG }}
+          tags: ghcr.io/${{ github.repository_owner }}/promsnmp-metrics:${{ env.SHORT_GIT_SHA }},ghcr.io/${{ github.repository_owner }}/promsnmp-metrics:${{ env.VERSION }},ghcr.io/${{ github.repository_owner }}/promsnmp-metrics:${{ env.OCI_FLOATING_TAG }}


### PR DESCRIPTION
This PR updates the CI workflow to use the `GITHUB_TOKEN` for authentication with GHCR, which is more secure and easier to manage than a PAT. It also adds the necessary `packages: write` permission and makes the image tag dynamic using `github.repository_owner` so the workflow can run successfully on forks.